### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/src/cf/microservices.yaml
+++ b/src/cf/microservices.yaml
@@ -108,7 +108,7 @@ Resources:
         - LambdaExecutionRole
         - Arn
       Timeout: 60
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
   ServerlessRestApi:
     Type: 'AWS::ApiGateway::RestApi'
     DependsOn: 


### PR DESCRIPTION
CloudFormation templates in aws-sagemaker-pytorch-shop-by-style have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.